### PR TITLE
Allow multiple translation files for each locale

### DIFF
--- a/generator/templates-vue3/js/src/i18n.js
+++ b/generator/templates-vue3/js/src/i18n.js
@@ -13,7 +13,7 @@ function loadLocaleMessages() {
     const matched = key.match(/([A-Za-z0-9-_]+)\./i)
     if (matched && matched.length > 1) {
       const locale = matched[1]
-      messages[locale] = locales(key).default
+      messages[locale] = {...messages[locale], ...locales(key).default}
     }
   })
   return messages

--- a/generator/templates-vue3/ts/src/i18n.ts
+++ b/generator/templates-vue3/ts/src/i18n.ts
@@ -13,7 +13,7 @@ function loadLocaleMessages(): LocaleMessages<VueMessageType> {
     const matched = key.match(/([A-Za-z0-9-_]+)\./i)
     if (matched && matched.length > 1) {
       const locale = matched[1]
-      messages[locale] = locales(key).default
+      messages[locale] = {...messages[locale], ...locales(key).default}
     }
   })
   return messages

--- a/generator/templates/js/src/i18n.js
+++ b/generator/templates/js/src/i18n.js
@@ -10,7 +10,7 @@ function loadLocaleMessages () {
     const matched = key.match(/([A-Za-z0-9-_]+)\./i)
     if (matched && matched.length > 1) {
       const locale = matched[1]
-      messages[locale] = locales(key)
+      messages[locale] = {...messages[locale], ...locales(key)}
     }
   })
   return messages

--- a/generator/templates/ts/src/i18n.ts
+++ b/generator/templates/ts/src/i18n.ts
@@ -10,7 +10,7 @@ function loadLocaleMessages (): LocaleMessages {
     const matched = key.match(/([A-Za-z0-9-_]+)\./i)
     if (matched && matched.length > 1) {
       const locale = matched[1]
-      messages[locale] = locales(key)
+      messages[locale] = {...messages[locale], ...locales(key)}
     }
   })
   return messages


### PR DESCRIPTION
This PR modified i18n.js (or .ts) so that multiple files from src/locales can be used as translations for every locale. Having translations in multiple files like en.menu.json, en.articles.json,... makes maintenance of translations much easier.